### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+coinor-ipopt (3.11.9-3) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + coinor-libipopt-doc: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 22 Apr 2021 02:03:28 -0000
+
 coinor-ipopt (3.11.9-2) unstable; urgency=low
 
   * Link against sequential MUMPS instead of parallel (Closes: #763612)

--- a/debian/control
+++ b/debian/control
@@ -51,6 +51,7 @@ Package: coinor-libipopt-doc
 Section: doc
 Architecture: all
 Depends: libjs-jquery, ${misc:Depends}
+Multi-Arch: foreign
 Description: Interior-Point Optimizer - documentation
  Ipopt is an open-source solver for large-scale nonlinear continuous
  optimization. It can be used from modeling environments, such as AMPL,
@@ -82,4 +83,3 @@ Description: Interior-Point Optimizer - debugging symbols
  the available solvers that is Free Software and included in Debian).
  .
  This package contains the debugging symbols.
-


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/coinor-ipopt/693a482b-8347-4198-a4e2-c39b6caf4dbe.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/IpOptFSS_2resource_8h.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/IpOptFSS_2resource_8h_source.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/IpOpt_2resource_8h.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/IpOpt_2resource_8h_source.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/classIpopt_1_1DependentResult.png
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/classIpopt_1_1Observer.png
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/doxygen.svg
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/search/close.svg
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/search/mag_sel.svg
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/SS_2resource_8h.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/SS_2resource_8h_source.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/doxygen.png
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/namespaceorg.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/namespaceorg_1_1coinor.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/resource_8h.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/resource_8h_source.html
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/search/close.png
    -rw-r--r--  root/root   /usr/share/doc/coinor-libipopt-doc/html/search/mag_sel.png

No differences were encountered between the control files of package \*\*coinor-libipopt-dev\*\*
### Control files of package coinor-libipopt-doc: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}
### Control files of package coinor-libipopt1: lines which differ (wdiff format)
* Depends: libblas3 | libblas.so.3, libc6 (>= 2.29), libgcc-s1 (>= 3.0), liblapack3 | liblapack.so.3, [-libmumps-seq-5.3.1-] {+libmumps-seq-5.3+} (>= [-5.3.1),-] {+5.3.5),+} libstdc++6 (>= 5.2)

No differences were encountered between the control files of package \*\*coinor-libipopt1-dbg\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/693a482b-8347-4198-a4e2-c39b6caf4dbe/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/693a482b-8347-4198-a4e2-c39b6caf4dbe/diffoscope)).
